### PR TITLE
NullFrame - Remove usage of 0-Channel audio frames

### DIFF
--- a/includes/Graph/AudioNode.h
+++ b/includes/Graph/AudioNode.h
@@ -5,14 +5,20 @@
 #include <vector>
 
 #include "AudioFrame.h"
-#include "FrameHistory.h"
 #include "Node.h"
+#include "NullFrame.h"
 
 namespace Clover::Graph {
 
 /// Base class for all N channel nodes of the audio graph.
 template <size_t __arityInput, size_t __arityOutput>
-class AudioNode : public Node<Graph::AudioFrame<__arityInput>,
-                              Graph::AudioFrame<__arityOutput>> {};
+class AudioNode
+    : public Node<AudioFrame<__arityInput>, AudioFrame<__arityOutput>> {};
+
+template <size_t __arity>
+class AudioInNode : public Node<AudioFrame<__arity>, NullFrame> {};
+
+template <size_t __arity>
+class AudioOutNode : public Node<NullFrame, AudioFrame<__arity>> {};
 
 } // namespace Clover::Graph

--- a/includes/Graph/FrameConcept.h
+++ b/includes/Graph/FrameConcept.h
@@ -2,26 +2,26 @@
 
 #include <concepts>
 
-// clang-format off 
+// clang-format off
 template <typename T>
 concept Frame = requires(T a, const T b, const T c, const float f) {
-  T();
+                  T();
 
-  { a.init() } -> std::same_as<void>;
+                  { a.init() } -> std::same_as<void>;
 
-  { b + c } -> std::same_as<T>;
-  { b - c } -> std::same_as<T>;
-  { b * c } -> std::same_as<T>;
-  { b / c } -> std::same_as<T>;
+                  { b + c } -> std::same_as<T>;
+                  { b - c } -> std::same_as<T>;
+                  { b *c } -> std::same_as<T>;
+                  { b / c } -> std::same_as<T>;
 
-  { a += b } -> std::same_as<void>;
-  { a -= b } -> std::same_as<void>;
-  { a *= b } -> std::same_as<void>;
-  { a /= b } -> std::same_as<void>;
+                  { a += b } -> std::same_as<void>;
+                  { a -= b } -> std::same_as<void>;
+                  { a *= b } -> std::same_as<void>;
+                  { a /= b } -> std::same_as<void>;
 
-  { a += f } -> std::same_as<void>;
-  { a -= f } -> std::same_as<void>;
-  { a *= f } -> std::same_as<void>;
-  { a /= f } -> std::same_as<void>;
-};
-// clang-format on 
+                  { a += f } -> std::same_as<void>;
+                  { a -= f } -> std::same_as<void>;
+                  { a *= f } -> std::same_as<void>;
+                  { a /= f } -> std::same_as<void>;
+                };
+// clang-format on

--- a/includes/Graph/FrameConcept.h
+++ b/includes/Graph/FrameConcept.h
@@ -2,24 +2,26 @@
 
 #include <concepts>
 
+// clang-format off 
 template <typename T>
 concept Frame = requires(T a, const T b, const T c, const float f) {
-                  T();
+  T();
 
-                  { a.init() } -> std::same_as<void>;
+  { a.init() } -> std::same_as<void>;
 
-                  { b + c } -> std::same_as<T>;
-                  { b - c } -> std::same_as<T>;
-                  { b *c } -> std::same_as<T>;
-                  { b / c } -> std::same_as<T>;
+  { b + c } -> std::same_as<T>;
+  { b - c } -> std::same_as<T>;
+  { b * c } -> std::same_as<T>;
+  { b / c } -> std::same_as<T>;
 
-                  { a += b } -> std::same_as<void>;
-                  { a -= b } -> std::same_as<void>;
-                  { a *= b } -> std::same_as<void>;
-                  { a /= b } -> std::same_as<void>;
+  { a += b } -> std::same_as<void>;
+  { a -= b } -> std::same_as<void>;
+  { a *= b } -> std::same_as<void>;
+  { a /= b } -> std::same_as<void>;
 
-                  { a += f } -> std::same_as<void>;
-                  { a -= f } -> std::same_as<void>;
-                  { a *= f } -> std::same_as<void>;
-                  { a /= f } -> std::same_as<void>;
-                };
+  { a += f } -> std::same_as<void>;
+  { a -= f } -> std::same_as<void>;
+  { a *= f } -> std::same_as<void>;
+  { a /= f } -> std::same_as<void>;
+};
+// clang-format on 

--- a/includes/Graph/NullFrame.h
+++ b/includes/Graph/NullFrame.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <array>
+#include <cstdio>
+
+#include "Constants.h"
+
+namespace Clover::Graph {
+
+struct NullFrame {
+
+  NullFrame() {}
+  NullFrame(std::initializer_list<Sample> init) {}
+
+  NullFrame operator+(const Graph::NullFrame &b) const { return b; }
+
+  NullFrame operator-(const Graph::NullFrame &b) const { return b; }
+
+  Graph::NullFrame operator*(const Graph::NullFrame &b) const { return b; }
+
+  Graph::NullFrame operator/(const Graph::NullFrame &b) const { return b; }
+
+  void operator+=(const Graph::NullFrame &b) {}
+
+  void operator-=(const Graph::NullFrame &b) {}
+
+  void operator*=(const Graph::NullFrame &b) {}
+
+  void operator/=(const Graph::NullFrame &b) {}
+
+  void operator+=(const float b) {}
+
+  void operator-=(const float b) {}
+
+  void operator*=(const float b) {}
+
+  void operator/=(const float b) {}
+
+  void init() {}
+};
+
+} // namespace Clover::Graph

--- a/includes/Graph/NullNode.h
+++ b/includes/Graph/NullNode.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <functional>
+#include <stdexcept>
+#include <vector>
+
+#include "Node.h"
+#include "NullFrame.h"
+
+namespace Clover::Graph {
+
+/// Base class for Nodes that do not exchange data but still need to be
+/// connected to the graph
+class NullNode : public Node<NullFrame, NullFrame> {};
+
+} // namespace Clover::Graph

--- a/includes/NodeComplex/OscNx.h
+++ b/includes/NodeComplex/OscNx.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "Clover.h"
-#include "Graph.h"
+#include "Graph/AudioFrame.h"
+#include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 #include "NodeSimplex.h"
+#include "NodeSimplex/Adapter/NullAdapter.h"
 
 template <int __numVoices>
-struct OscNx : public Clover::Graph::AudioNode<0, 2>, Pitchable, Triggerable {
+struct OscNx : public Clover::Graph::AudioOutNode<2>, Pitchable, Triggerable {
   struct Voice {
     Voice() : tuning_(0) {}
 
@@ -103,11 +106,11 @@ struct OscNx : public Clover::Graph::AudioNode<0, 2>, Pitchable, Triggerable {
 
   float currentMidiNoteFreq;
 
-  Clover::NodeSimplex::Adapter::NullAdapter<1, 0> blackHole1;
-  Clover::NodeSimplex::Adapter::NullAdapter<2, 0> blackHole2;
+  Clover::NodeSimplex::Adapter::NullOutAdapter<1> blackHole1;
+  Clover::NodeSimplex::Adapter::NullOutAdapter<2> blackHole2;
   Clover::NodeSimplex::Basic::Gain<2> audioSink;
 
-  Clover::Graph::AudioFrame<2> tick(Clover::Graph::AudioFrame<0> input) {
+  Clover::Graph::AudioFrame<2> tick(Clover::Graph::NullFrame input) {
     updatePitchMod();
     updateFilterMod();
     updateAmplitudeMod();

--- a/includes/NodeSimplex/Adapter/NullAdapter.h
+++ b/includes/NodeSimplex/Adapter/NullAdapter.h
@@ -1,16 +1,25 @@
 #pragma once
 
-#include "Graph.h"
+#include "Graph/AudioFrame.h"
+#include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 
 namespace Clover::NodeSimplex::Adapter {
 
-// I am not a fan of this Node, but as for now it is required in order to
-// create a block hole for signals. Think /dev/null for signals.
-template <size_t __arityIn, size_t __arityOut>
-class NullAdapter : public Graph::AudioNode<__arityIn, __arityOut> {
+// Think /dev/null for signals.
+template <size_t __arityOut>
+class NullInAdapter : public Graph::AudioOutNode<__arityOut> {
 
-  Graph::AudioFrame<__arityOut> tick(Graph::AudioFrame<__arityIn> input) {
+  Graph::AudioFrame<__arityOut> tick(Graph::NullFrame input) {
     return Graph::AudioFrame<__arityOut>{};
+  }
+};
+
+template <size_t __arityIn>
+class NullOutAdapter : public Graph::AudioInNode<__arityIn> {
+
+  Graph::NullFrame tick(Graph::AudioFrame<__arityIn> input) {
+    return Graph::NullFrame{};
   }
 };
 

--- a/includes/NodeSimplex/StepSequencer/StepSequencer.h
+++ b/includes/NodeSimplex/StepSequencer/StepSequencer.h
@@ -4,7 +4,8 @@
 #include <functional>
 #include <vector>
 
-#include "Graph.h"
+#include "Graph/NullFrame.h"
+#include "Graph/NullNode.h"
 
 struct PatternSettable {
   virtual void setPattern(int i);
@@ -45,9 +46,9 @@ template <typename T> struct STSQ_Pattern {
 template <typename StepDataType, typename TargetType,
           void (*applyStepDataFunc)(const StepDataType &,
                                     std::vector<TargetType *> &)>
-struct STSQ : public Clover::Graph::AudioNode<0, 0>, public PatternSettable {
+struct STSQ : public Clover::Graph::NullNode, public PatternSettable {
 
-  STSQ() : AudioNode(), nextIndex(0), patternIndex(0) {}
+  STSQ() : NullNode(), nextIndex(0), patternIndex(0) {}
 
   int patternIndex;
   std::vector<STSQ_Pattern<StepDataType>> patterns;
@@ -64,10 +65,10 @@ struct STSQ : public Clover::Graph::AudioNode<0, 0>, public PatternSettable {
     patterns.emplace_back(newPattern);
   }
 
-  Clover::Graph::AudioFrame<0> tick(Clover::Graph::AudioFrame<0> input) {
+  Clover::Graph::NullFrame tick(Clover::Graph::NullFrame input) {
     checkTimeAndPerformStep();
 
-    return Clover::Graph::AudioFrame<0>{};
+    return input;
   }
 
 private:

--- a/includes/NodeSimplex/Wavetable/WavetableOsc.cpp
+++ b/includes/NodeSimplex/Wavetable/WavetableOsc.cpp
@@ -5,7 +5,9 @@
 #include <vector>
 
 #include "Base.h"
-#include "Graph.h"
+#include "Graph/AudioNode.h"
+#include "Graph/AudioFrame.h"
+#include "Graph/NullFrame.h"
 #include "Util.h"
 
 #include "WavetableOsc.h"
@@ -21,7 +23,7 @@ WavetableOsc::WavetableOsc()
                      200, 0, 0) {}
 
 WavetableOsc::WavetableOsc(std::shared_ptr<Wavetable> wavetable, float freq, float phase, float phaseOffset)
-    : Clover::Graph::AudioNode<0, 1>(), osc(Base::sampleRate, wavetable) {
+    : Clover::Graph::AudioOutNode<1>(), osc(Base::sampleRate, wavetable) {
 }
 
 void WavetableOsc::phase(float phasePercent) {
@@ -96,7 +98,7 @@ void WavetableOsc::noiseWhite(int size) {
   osc.noiseWhite(size);
 }
 
-Graph::AudioFrame<1> WavetableOsc::tick(Graph::AudioFrame<0> input) {
+Graph::AudioFrame<1> WavetableOsc::tick(Graph::NullFrame input) {
   return Graph::AudioFrame<1> { osc.process() };
 }
 

--- a/includes/NodeSimplex/Wavetable/WavetableOsc.h
+++ b/includes/NodeSimplex/Wavetable/WavetableOsc.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <cmath>
 #include <functional>
 #include <memory>
@@ -9,14 +10,15 @@
 #include "Algo/Wavetable/WavetableOscillatorMono.h"
 #include "Graph/AudioFrame.h"
 #include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 #include "WavetableOscInterface.h"
 
 namespace Clover::NodeSimplex::Wavetable {
 
 typedef std::vector<Sample> Wavetable;
 
-struct WavetableOsc : public Base,
-                      public Graph::AudioNode<0, 1>,
+struct WavetableOsc : public Graph::AudioOutNode<1>,
+                      public Base,
                       public Clover::Wavetable::WavetableOscInterface<float> {
   WavetableOsc();
   WavetableOsc(std::shared_ptr<Wavetable> wavetable, float freq,
@@ -47,7 +49,7 @@ struct WavetableOsc : public Base,
   void noiseWhite(int size = 1024);
 
 private:
-  Graph::AudioFrame<1> tick(Graph::AudioFrame<0> input) override;
+  Graph::AudioFrame<1> tick(Graph::NullFrame input) override;
   Clover::Wavetable::WavetableOscillatorMono<Sample> osc;
 };
 

--- a/includes/NodeSimplex/Wavetable/WavetableOscStereo.cpp
+++ b/includes/NodeSimplex/Wavetable/WavetableOscStereo.cpp
@@ -97,7 +97,7 @@ void WavetableOscStereo::noise(int size) {
   oscR.wavetable(oscL.wavetable());
 }
 
-Graph::AudioFrame<2> WavetableOscStereo::tick(Graph::AudioFrame<0> input) {
+Graph::AudioFrame<2> WavetableOscStereo::tick(Graph::NullFrame input) {
   return Graph::AudioFrame<2>{oscL.frames.current[0], oscR.frames.current[0]};
 }
 

--- a/includes/NodeSimplex/Wavetable/WavetableOscStereo.h
+++ b/includes/NodeSimplex/Wavetable/WavetableOscStereo.h
@@ -5,13 +5,16 @@
 #include <tgmath.h>
 #include <vector>
 
+#include "Graph/AudioFrame.h"
+#include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 #include "NodeSimplex.h"
 #include "WavetableOsc.h"
 
 namespace Clover::NodeSimplex::Wavetable {
 
 class WavetableOscStereo : public Base,
-                           public Graph::AudioNode<0, 2>,
+                           public Graph::AudioOutNode<2>,
                            public WavetableOscInterface {
 public:
   WavetableOscStereo();
@@ -44,7 +47,7 @@ public:
 private:
   WavetableOsc oscL;
   WavetableOsc oscR;
-  Adapter::NullAdapter<1, 0> blackHole;
+  Adapter::NullOutAdapter<1> blackHole;
 
   float stereoDetune_L_semi;
   float stereoDetune_R_semi;
@@ -52,7 +55,7 @@ private:
 
   float freq_;
 
-  Graph::AudioFrame<2> tick(Graph::AudioFrame<0> input);
+  Graph::AudioFrame<2> tick(Graph::NullFrame input);
 
   void connectNodes();
   void updateFreq();

--- a/includes/_Test/Collector.h
+++ b/includes/_Test/Collector.h
@@ -1,14 +1,15 @@
 #pragma once
 #include <string>
 
-#include "Graph.h"
+#include "Graph/AudioFrame.h"
+#include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 
 namespace Clover::_Test {
 
-template <size_t __arity>
-class Collector : public Graph::AudioNode<__arity, __arity> {
+template <size_t __arity> class Collector : public Graph::AudioInNode<__arity> {
 public:
-  Collector(int preAllocateFrames) : Graph::AudioNode<__arity, __arity>() {
+  Collector(int preAllocateFrames) : Graph::AudioInNode<__arity>() {
     frames.reserve(preAllocateFrames);
   }
 
@@ -30,10 +31,10 @@ public:
   }
 
 private:
-  Graph::AudioFrame<__arity> tick(Graph::AudioFrame<__arity> input) {
+  Graph::NullFrame tick(Graph::AudioFrame<__arity> input) {
     frames.emplace_back(input);
 
-    return input;
+    return Graph::NullFrame{};
   }
 };
 

--- a/includes/_Test/DCN.h
+++ b/includes/_Test/DCN.h
@@ -1,19 +1,21 @@
 #pragma once
 
+#include "Graph/AudioFrame.h"
 #include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 
 namespace Clover::_Test {
 
 template <size_t __arityOut>
-class DCN : public Graph::AudioNode<0, __arityOut> {
+class DCN : public Graph::AudioOutNode<__arityOut> {
 public:
-  DCN() : Graph::AudioNode<0, __arityOut>(), basis(0.f) {}
+  DCN() : Graph::AudioOutNode<__arityOut>(), basis(0.f) {}
 
   void indexBasis(float b) { basis = b; }
 
 private:
   float basis;
-  Graph::AudioFrame<__arityOut> tick(Graph::AudioFrame<0> input) {
+  Graph::AudioFrame<__arityOut> tick(Graph::NullFrame input) {
     Graph::AudioFrame<__arityOut> f{};
 
     for (int i = 0; i < __arityOut; i++) {

--- a/includes/_Test/HandCrank.h
+++ b/includes/_Test/HandCrank.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "Graph.h"
+#include "Graph/NullFrame.h"
+#include "Graph/NullNode.h"
 #include "Util/SampleClock.h"
 
 namespace Clover::_Test {
 
-template <size_t __arityIn>
-class HandCrank : public Graph::AudioNode<__arityIn, 0> {
+class HandCrank : public Graph::NullNode {
 public:
-  HandCrank() : Graph::AudioNode<__arityIn, 0>() {}
+  HandCrank() : Graph::NullNode() {}
 
   void turn(int numberOfTicks) {
     for (int i = 0; i < numberOfTicks; i++) {
@@ -20,9 +20,7 @@ public:
 private:
   Clover::Util::SampleClock clock;
 
-  Graph::AudioFrame<0> tick(Graph::AudioFrame<__arityIn> input) {
-    return Graph::AudioFrame<0>{};
-  }
+  Graph::NullFrame tick(Graph::NullFrame input) { return Graph::NullFrame{}; }
 };
 
 } // namespace Clover::_Test

--- a/includes/_Test/Incrementor.h
+++ b/includes/_Test/Incrementor.h
@@ -1,18 +1,20 @@
 #pragma once
 
-#include "Graph.h"
+#include "Graph/AudioFrame.h"
+#include "Graph/AudioNode.h"
+#include "Graph/NullFrame.h"
 
 namespace Clover::_Test {
 
 template <size_t __arityOut>
-class Incrementor : public Graph::AudioNode<0, __arityOut> {
+class Incrementor : public Graph::AudioOutNode<__arityOut> {
 public:
   Incrementor(int startValue = 0)
-      : Graph::AudioNode<0, __arityOut>(), basis(startValue) {}
+      : Graph::AudioOutNode<__arityOut>(), basis(startValue) {}
 
 private:
   float basis;
-  Graph::AudioFrame<__arityOut> tick(Graph::AudioFrame<0> input) {
+  Graph::AudioFrame<__arityOut> tick(Graph::NullFrame input) {
     Graph::AudioFrame<__arityOut> f{};
 
     float time = (float)this->_currentClockTime;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,8 +36,10 @@ int main(int argc, char *argv[]) {
   Interface interface;
   interface.rootNode.gain(0.5);
   Clover::Util::Time time(160, Clover::Base::sampleRate, &interface.clock);
-  Clover::NodeSimplex::Adapter::NullAdapter<1, 2> blackHole;
-  blackHole >> interface.rootNode;
+  Clover::NodeSimplex::Adapter::NullInAdapter<2> nullSink;
+  Clover::NodeSimplex::Adapter::NullOutAdapter<1> blackHole1;
+
+  blackHole1 >> nullSink >> interface.rootNode;
 
   Wavetable::WavetableOscStereo osc;
   osc.saw(1024);
@@ -48,7 +50,7 @@ int main(int argc, char *argv[]) {
   mod.sine(11);
   mod.freq(71);
 
-  mod >> blackHole;
+  mod >> blackHole1;
 
   Filter::Filter<2> filter;
   filter.lowPass();
@@ -65,20 +67,18 @@ int main(int argc, char *argv[]) {
   lfo.sine(1024);
   lfo.freq(0.25);
   lfo.phase(0.75);
-  lfo >> blackHole;
+  lfo >> blackHole1;
 
   Envelope::ADSR adsr(time.quat(0.22), time.quat(), 0.0f, time.beat());
-  adsr >> blackHole;
+  adsr >> blackHole1;
 
   OscAndStSq testPattern(time);
 
-  Adapter::NullAdapter<0, 2> nullAdapter;
-
   testPattern.instrument >> interface.rootNode;
   testPattern.kick >> interface.rootNode;
-  testPattern.stsq_pitch >> nullAdapter >> interface.rootNode;
-  testPattern.stsq_kick >> nullAdapter;
-  testPattern.stsq_trigger >> nullAdapter;
+  testPattern.stsq_pitch >> nullSink;
+  testPattern.stsq_kick >> nullSink;
+  testPattern.stsq_trigger >> nullSink;
 
   bool isProfilingMode = false;
   if (isProfilingMode) {

--- a/test/Graph/Node_Test.cc
+++ b/test/Graph/Node_Test.cc
@@ -34,7 +34,7 @@ TEST(Graph_Node, ShouldConnect) {
 
 TEST(Graph_Node, ShouldSumAndGain) {
 
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(1);
 
   NodeStub stub1;

--- a/test/NodeSimplex/Basic/Gain_Test.cc
+++ b/test/NodeSimplex/Basic/Gain_Test.cc
@@ -3,7 +3,7 @@
 #include "Clover.h"
 
 TEST(NodeSimplex_Basic_Gain, ShouldNotModify) {
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(1);
   Clover::NodeSimplex::Basic::Gain<1> g;
   Clover::_Test::DCN<1> dc;
@@ -21,7 +21,7 @@ TEST(NodeSimplex_Basic_Gain, ShouldNotModify) {
 }
 
 TEST(NodeSimplex_Basic_Gain, ShouldModify) {
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(3);
   Clover::NodeSimplex::Basic::Gain<1> g;
   Clover::_Test::DCN<1> dc;

--- a/test/NodeSimplex/Envelope/AutomationClip_Test.cc
+++ b/test/NodeSimplex/Envelope/AutomationClip_Test.cc
@@ -4,7 +4,7 @@
 
 TEST(NodeSimplex_Envelope_AutomationClip, ShouldOutputEnvelope) {
 
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(1000);
   Clover::NodeSimplex::AutomationNode automationClip;
 
@@ -31,7 +31,7 @@ TEST(NodeSimplex_Envelope_AutomationClip, ShouldOutputEnvelope) {
 
 TEST(NodeSimplex_Envelope_AutomationClip, ShouldHaveDefaultEnvelope) {
 
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(10);
   Clover::NodeSimplex::AutomationNode automationClip;
 
@@ -47,7 +47,7 @@ TEST(NodeSimplex_Envelope_AutomationClip, ShouldHaveDefaultEnvelope) {
 
 TEST(NodeSimplex_Envelope_AutomationClip, ShouldHoldLastValue) {
 
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(10);
   Clover::NodeSimplex::AutomationNode automationClip;
 

--- a/test/NodeSimplex/Filter/Filter_Test.cc
+++ b/test/NodeSimplex/Filter/Filter_Test.cc
@@ -8,7 +8,7 @@
 TEST(NodeSimplex_Filter_Filter, ShouldFilterLowPass) {
 
   int testSize = 10000;
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(testSize);
   Clover::NodeSimplex::Filter::Filter<1> filter;
   Clover::NodeSimplex::Wavetable::WavetableOsc osc;
@@ -35,7 +35,7 @@ TEST(NodeSimplex_Filter_Filter, ShouldFilterLowPass) {
 TEST(NodeSimplex_Filter_Filter, ShouldFilterHighPass) {
 
   int testSize = 10000;
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(testSize);
   Clover::NodeSimplex::Filter::Filter<1> filter;
   Clover::NodeSimplex::Wavetable::WavetableOsc osc;

--- a/test/NodeSimplex/NodeSmokeTests.cc
+++ b/test/NodeSimplex/NodeSmokeTests.cc
@@ -16,23 +16,10 @@
 #include "NodeSimplex/Stereo/Sum.h"
 #include "NodeSimplex/Wavetable/WavetableOscStereo.h"
 
-TEST(NodeSimplex_SmokeTest, NullAdapter) {
-  Clover::_Test::HandCrank<1> crank;
-  Clover::_Test::Collector<1> collector(1);
-  Clover::NodeSimplex::Adapter::NullAdapter<4, 1> nullAdapter;
-  Clover::_Test::DCN<4> dc;
-
-  dc >> nullAdapter >> collector >> crank;
-
-  crank.turn(1);
-
-  EXPECT_EQ(collector.frames[0][0], 0.f);
-}
-
 TEST(NodeSimplex_SmokeTest, Delay_Fractional) {
   float delayTime = 1.f;
   int testSize = delayTime + 10;
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::NodeSimplex::Delay::FractionalDelayLine<1> delay(testSize, delayTime);
   Clover::_Test::Collector<1> delayCollector(testSize);
   Clover::_Test::Incrementor<1> incrementor(1);
@@ -52,7 +39,7 @@ TEST(NodeSimplex_SmokeTest, Delay_Fractional) {
 }
 
 TEST(NodeSimplex_SmokeTest, DynamicRange_Clamp) {
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> envelopeCollector(6);
   Clover::NodeSimplex::DynamicRange::AsymClip<1> clip;
   Clover::_Test::DCN<1> dc;
@@ -82,7 +69,7 @@ TEST(NodeSimplex_SmokeTest, DynamicRange_Clamp) {
 }
 
 TEST(NodeSimplex_SmokeTest, Envelope_Basic) {
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::NodeSimplex::Envelope::BasicEnvelope envelope;
   Clover::_Test::Collector<1> envelopeCollector(100);
 
@@ -106,7 +93,7 @@ TEST(NodeSimplex_SmokeTest, Envelope_Basic) {
 }
 
 TEST(NodeSimplex_SmokeTest, Envelope_ADSR) {
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::NodeSimplex::Envelope::ADSR envelope;
   Clover::_Test::Collector<1> envelopeCollector(100);
 
@@ -129,7 +116,7 @@ TEST(NodeSimplex_SmokeTest, Envelope_ADSR) {
 }
 
 TEST(NodeSimplex_SmokeTest, Stereo_Difference) {
-  Clover::_Test::HandCrank<2> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<2> collector(2);
   Clover::NodeSimplex::Stereo::Difference difference;
   Clover::_Test::DCN<2> dc;
@@ -144,7 +131,7 @@ TEST(NodeSimplex_SmokeTest, Stereo_Difference) {
 }
 
 TEST(NodeSimplex_SmokeTest, Stereo_MidSideBalance) {
-  Clover::_Test::HandCrank<2> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<2> collector(3);
   Clover::NodeSimplex::Stereo::MidSideBalance ms;
   Clover::_Test::DCN<2> dc;
@@ -174,7 +161,7 @@ TEST(NodeSimplex_SmokeTest, Stereo_Pan1) {
   Clover::NodeSimplex::Wavetable::WavetableOsc wavetableDC;
   wavetableDC.wavetable(wt);
 
-  Clover::_Test::HandCrank<2> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<2> collector(3);
   Clover::NodeSimplex::Stereo::Pan1 pan;
 
@@ -202,7 +189,7 @@ TEST(NodeSimplex_SmokeTest, Stereo_Pan2) {
   Clover::NodeSimplex::Wavetable::WavetableOscStereo wavetableDC;
   wavetableDC.wavetable(wt);
 
-  Clover::_Test::HandCrank<2> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<2> collector(3);
   Clover::NodeSimplex::Stereo::Pan2 pan;
 
@@ -224,7 +211,7 @@ TEST(NodeSimplex_SmokeTest, Stereo_Pan2) {
 }
 
 TEST(NodeSimplex_SmokeTest, Sum_Mono) {
-  Clover::_Test::HandCrank<1> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<1> collector(1);
   Clover::NodeSimplex::Stereo::Sum1 sum;
   Clover::_Test::DCN<2> dc;
@@ -238,7 +225,7 @@ TEST(NodeSimplex_SmokeTest, Sum_Mono) {
 }
 
 TEST(NodeSimplex_SmokeTest, Sum_Stereo) {
-  Clover::_Test::HandCrank<2> crank;
+  Clover::_Test::HandCrank crank;
   Clover::_Test::Collector<2> collector(1);
   Clover::NodeSimplex::Stereo::Sum2 sum;
   Clover::_Test::DCN<2> dc;

--- a/test/NodeSimplex/StepSequencer/STSQ_Test.cc
+++ b/test/NodeSimplex/StepSequencer/STSQ_Test.cc
@@ -21,7 +21,7 @@ void TestFacilitator(const int &data, std::vector<TestTarget *> &targets) {
 
 TEST(NodeSimplex_StepSequencer, ShouldStepCorrectly) {
 
-  Clover::_Test::HandCrank<0> crank;
+  Clover::_Test::HandCrank crank;
   STSQ<int, TestTarget, TestFacilitator> stepSequencer;
   stepSequencer >> crank;
 
@@ -48,7 +48,7 @@ TEST(NodeSimplex_StepSequencer, ShouldStepCorrectly) {
 
 TEST(NodeSimplex_StepSequencer, ShouldBeAbleToChangePattern) {
 
-  Clover::_Test::HandCrank<0> crank;
+  Clover::_Test::HandCrank crank;
   STSQ<int, TestTarget, TestFacilitator> stepSequencer;
   stepSequencer >> crank;
 


### PR DESCRIPTION
There is an ongoing effort to generalize and de-audio the  non-audio concepts in the Graph. This PR represents significant progress in that goal

- Created NullFrame class that satifies the Frame concept
- Created AudioInNode and AudioOutNode base classes for Nodes that only accept OR provide audio signals
- Replaced usage of AudioFrame<0>, Node<0, N>, and Node<N, 0> with the above concepts